### PR TITLE
Remove ports from `inner` when the connection/listener is dropped

### DIFF
--- a/src/listener.rs
+++ b/src/listener.rs
@@ -58,4 +58,9 @@ impl<T: AsyncRead + AsyncWrite + Send + Unpin + 'static> MuxListener<T> {
             .await
             .map_err(|e| io::Error::new(io::ErrorKind::Other, e))
     }
+
+    /// Get the port number of this listener
+    pub fn port(&self) -> u16 {
+        self.port
+    }
 }

--- a/src/listener.rs
+++ b/src/listener.rs
@@ -12,6 +12,10 @@ use tracing::{error, trace};
 use crate::{inner::StreamMultiplexorInner, Result};
 
 /// Listener struct returned by `StreamMultiplexor<T>::bind()`
+///
+/// # Drop
+/// When the listener is dropped, it will free the port for reuse, but established
+/// connections will not be closed.
 pub struct MuxListener<T> {
     inner: Arc<StreamMultiplexorInner<T>>,
     port: u16,
@@ -39,7 +43,8 @@ impl<T> Debug for MuxListener<T> {
 
 impl<T> Drop for MuxListener<T> {
     fn drop(&mut self) {
-        error!("drop {:?}", self);
+        self.inner.may_close_listeners.send(self.port).ok();
+        debug!("drop {:?}", self);
     }
 }
 

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -54,7 +54,11 @@ impl<T> Debug for MuxSocket<T> {
 
 impl<T> Drop for MuxSocket<T> {
     fn drop(&mut self) {
-        error!("drop {:?}", self);
+        self.inner
+            .may_close_connections
+            .send((self.sport, self.dport))
+            .ok();
+        debug!("drop {:?}", self);
     }
 }
 


### PR DESCRIPTION
I'm not sure if you will find this change set useful. I basically added two `mpsc`s so that when `MuxListener` and `MuxSocket` are `Drop`ped, their ports can be reused in the mux.

# But Whyyyyyy?
Because I needed it.

BTW, Thank you for this project.